### PR TITLE
Message not going to a specified channel

### DIFF
--- a/Service/SlackBot.php
+++ b/Service/SlackBot.php
@@ -107,6 +107,7 @@ class SlackBot
         $slackMessage = $this->validator->setDefaultsForEmptyFields($slackMessage, $this->getConfig());
 
         $return['text'] = $slackMessage->getText();
+        $return['channel'] = $slackMessage->getRecipient();
         $return['mrkdwn'] = true;
 
         if ($slackMessage->isShowQuote()) {


### PR DESCRIPTION
I am 99% sure I am missing something with this, but messages were only getting delivered to the channel specified in the webhook config setting in slack.  Looking at the JSON being generated for the curl request I can't see the channel getting set.

Can I be the only person to have this problem?  I found that adding the channel  in buildPostBody worked and the curl request now has the channel set and it works as I expected it to.

```
	$slackBot =$this->get('wowapps.slackbot');
	$slackMessage = new SlackMessage();
	$slackMessage
		->setText('I am a test message, did you get it?')
		->setRecipient('random');

	if (! $slackBot->sendMessage($slackMessage))
	{
		// Message not sent
	}
```

With this code the message gets posted into my #general channel (which is specified as the default channel for the webhook) rather than the #random channel.

| Question             | Answer
| ---------------------| ---------
| Issue #              |
| Solution description |  

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
