### PR TITLE
fix(sender): add support for 'username' property (mapped to slackMess…

### DIFF
--- a/Service/SlackBot.php
+++ b/Service/SlackBot.php
@@ -112,6 +112,7 @@ class SlackBot
 
         $return['text'] = $slackMessage->getText();
         $return['channel'] = $slackMessage->getRecipient();
+        $return['username'] = $slackMessage->getSender();
         $return['mrkdwn'] = true;
         $return['as_user'] = false;
 


### PR DESCRIPTION
…age->sender)

| Question             | Answer
| ---------------------| ---------
| Issue #              | Sender parameter is never used
| Solution description |  Simply add it to the request body ;)

No more to say on that, pretty simple PR ;)
